### PR TITLE
Improved naming convention to avoid conflicts

### DIFF
--- a/Karte.xcodeproj/project.pbxproj
+++ b/Karte.xcodeproj/project.pbxproj
@@ -7,12 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		396DF69A1EA4E4EC00D3F322 /* LocationRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396DF6991EA4E4EC00D3F322 /* LocationRepresentable.swift */; };
-		39D5B7121EA012D600691937 /* Location.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39D5B7111EA012D600691937 /* Location.swift */; };
+		396DF69A1EA4E4EC00D3F322 /* KLocationRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396DF6991EA4E4EC00D3F322 /* KLocationRepresentable.swift */; };
+		39D5B7121EA012D600691937 /* KLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39D5B7111EA012D600691937 /* KLocation.swift */; };
 		39D5B7141EA01DB400691937 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39D5B7131EA01DB400691937 /* Extensions.swift */; };
-		39D5B7161EA02A5200691937 /* Mode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39D5B7151EA02A5200691937 /* Mode.swift */; };
-		39D5B7181EA02A7000691937 /* App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39D5B7171EA02A7000691937 /* App.swift */; };
-		39D5B71A1EA02A8000691937 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39D5B7191EA02A8000691937 /* Error.swift */; };
+		39D5B7161EA02A5200691937 /* KMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39D5B7151EA02A5200691937 /* KMode.swift */; };
+		39D5B7181EA02A7000691937 /* KApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39D5B7171EA02A7000691937 /* KApp.swift */; };
+		39D5B71A1EA02A8000691937 /* KError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39D5B7191EA02A8000691937 /* KError.swift */; };
 		52D6D9871BEFF229002C0205 /* Karte.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52D6D97C1BEFF229002C0205 /* Karte.framework */; };
 		52D6D9981BEFF375002C0205 /* Karte.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52D6D9961BEFF375002C0205 /* Karte.swift */; };
 		52D6D99B1BEFF375002C0205 /* KarteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52D6D9971BEFF375002C0205 /* KarteTests.swift */; };
@@ -30,12 +30,12 @@
 
 /* Begin PBXFileReference section */
 		39002DAB20A990F7004D277C /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
-		396DF6991EA4E4EC00D3F322 /* LocationRepresentable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LocationRepresentable.swift; path = Sources/LocationRepresentable.swift; sourceTree = "<group>"; };
-		39D5B7111EA012D600691937 /* Location.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Location.swift; path = Sources/Location.swift; sourceTree = "<group>"; };
+		396DF6991EA4E4EC00D3F322 /* KLocationRepresentable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = KLocationRepresentable.swift; path = Sources/KLocationRepresentable.swift; sourceTree = "<group>"; };
+		39D5B7111EA012D600691937 /* KLocation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = KLocation.swift; path = Sources/KLocation.swift; sourceTree = "<group>"; };
 		39D5B7131EA01DB400691937 /* Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Extensions.swift; path = Sources/Extensions.swift; sourceTree = "<group>"; };
-		39D5B7151EA02A5200691937 /* Mode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Mode.swift; path = Sources/Mode.swift; sourceTree = "<group>"; };
-		39D5B7171EA02A7000691937 /* App.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = App.swift; path = Sources/App.swift; sourceTree = "<group>"; };
-		39D5B7191EA02A8000691937 /* Error.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Error.swift; path = Sources/Error.swift; sourceTree = "<group>"; };
+		39D5B7151EA02A5200691937 /* KMode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = KMode.swift; path = Sources/KMode.swift; sourceTree = "<group>"; };
+		39D5B7171EA02A7000691937 /* KApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = KApp.swift; path = Sources/KApp.swift; sourceTree = "<group>"; };
+		39D5B7191EA02A8000691937 /* KError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = KError.swift; path = Sources/KError.swift; sourceTree = "<group>"; };
 		52D6D97C1BEFF229002C0205 /* Karte.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Karte.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		52D6D9861BEFF229002C0205 /* Karte Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Karte Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		52D6D9961BEFF375002C0205 /* Karte.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Karte.swift; path = Sources/Karte.swift; sourceTree = "<group>"; };
@@ -68,11 +68,11 @@
 			children = (
 				39002DAB20A990F7004D277C /* README.md */,
 				52D6D9961BEFF375002C0205 /* Karte.swift */,
-				39D5B7191EA02A8000691937 /* Error.swift */,
-				39D5B7171EA02A7000691937 /* App.swift */,
-				39D5B7151EA02A5200691937 /* Mode.swift */,
-				39D5B7111EA012D600691937 /* Location.swift */,
-				396DF6991EA4E4EC00D3F322 /* LocationRepresentable.swift */,
+				39D5B7191EA02A8000691937 /* KError.swift */,
+				39D5B7171EA02A7000691937 /* KApp.swift */,
+				39D5B7151EA02A5200691937 /* KMode.swift */,
+				39D5B7111EA012D600691937 /* KLocation.swift */,
+				396DF6991EA4E4EC00D3F322 /* KLocationRepresentable.swift */,
 				39D5B7131EA01DB400691937 /* Extensions.swift */,
 				52D6D9971BEFF375002C0205 /* KarteTests.swift */,
 				52D6D99C1BEFF38C002C0205 /* Configs */,
@@ -241,12 +241,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				39D5B7181EA02A7000691937 /* App.swift in Sources */,
-				39D5B7121EA012D600691937 /* Location.swift in Sources */,
+				39D5B7181EA02A7000691937 /* KApp.swift in Sources */,
+				39D5B7121EA012D600691937 /* KLocation.swift in Sources */,
 				39D5B7141EA01DB400691937 /* Extensions.swift in Sources */,
-				39D5B7161EA02A5200691937 /* Mode.swift in Sources */,
-				396DF69A1EA4E4EC00D3F322 /* LocationRepresentable.swift in Sources */,
-				39D5B71A1EA02A8000691937 /* Error.swift in Sources */,
+				39D5B7161EA02A5200691937 /* KMode.swift in Sources */,
+				396DF69A1EA4E4EC00D3F322 /* KLocationRepresentable.swift in Sources */,
+				39D5B71A1EA02A8000691937 /* KError.swift in Sources */,
 				52D6D9981BEFF375002C0205 /* Karte.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Launch a specific app with directions.
 
 ```swift
 let coordinate = CLLocationCoordinate2D(latitude: 52.5162746, longitude: 13.3755153)
-let berlin = Location(name: "Brandenburger Tor Berlin", coordinate: coordinate)
+let berlin = KLocation(name: "Brandenburger Tor Berlin", coordinate: coordinate)
 Karte.launch(app: .googleMaps, destination: berlin)
 ```
 
@@ -48,7 +48,7 @@ let alert = Karte.createPicker(destination: location)
 
 `.launch()`, `.presentPicker()` and `.createPicker()` have a few extra parameters with default values set that you can change to your liking. Most important to note would be an origin location, which can of course also be specified. Leaving it blank defaults to the user's current location in most apps.
 
-A mode of transport can also be specified, which would then filter unsupported apps from the picker. Be aware that trying to launch an app directly with a specific mode of transport will verify if the app supports that mode and throw an `Error.unsupportedMode` otherwise.
+A mode of transport can also be specified, which would then filter unsupported apps from the picker. Be aware that trying to launch an app directly with a specific mode of transport will verify if the app supports that mode and throw an `KError.unsupportedMode` otherwise.
 
 
 ## Caveat

--- a/Sources/KApp.swift
+++ b/Sources/KApp.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public enum App {
+public enum KApp {
     case appleMaps
     case googleMaps // https://developers.google.com/maps/documentation/ios/urlscheme
     case citymapper
@@ -20,7 +20,7 @@ public enum App {
     case yandex
     case moovit
 
-    static var all: [App] {
+    static var all: [KApp] {
         return [.appleMaps, .googleMaps, .citymapper, .transit, .lyft, .uber, .navigon, .waze, .yandex, .moovit]
     }
 
@@ -55,7 +55,7 @@ public enum App {
     }
 
     /// Validates if an app supports a mode. The given mode is optional and this defaults to `true` if the mode is `nil`.
-    func supports(mode: Mode?) -> Bool {
+    func supports(mode: KMode?) -> Bool {
         guard let mode = mode else {
             return true
         }
@@ -83,7 +83,7 @@ public enum App {
     // swiftlint:disable cyclomatic_complexity
     // swiftlint:disable function_body_length
     /// Build a query string for this app using the parameters. Returns nil if a mode is specified, but not supported by this app.
-    func queryString(origin: LocationRepresentable?, destination: LocationRepresentable, mode: Mode?) -> String? {
+    func queryString(origin: KLocationRepresentable?, destination: KLocationRepresentable, mode: KMode?) -> String? {
         guard self.supports(mode: mode) else {
             // if a mode is present, validate if the app supports it, otherwise we don't care
             return nil

--- a/Sources/KError.swift
+++ b/Sources/KError.swift
@@ -8,6 +8,6 @@
 
 import Foundation
 
-public enum Error: Swift.Error {
+public enum KError: Swift.Error {
     case unsupportedMode
 }

--- a/Sources/KLocation.swift
+++ b/Sources/KLocation.swift
@@ -11,7 +11,7 @@ import struct CoreLocation.CLLocationCoordinate2D
 import class MapKit.MKMapItem
 import class MapKit.MKPlacemark
 
-public struct Location {
+public struct KLocation {
     public let coordinate: CLLocationCoordinate2D
     public let name: String?
     public let address: String?

--- a/Sources/KLocationRepresentable.swift
+++ b/Sources/KLocationRepresentable.swift
@@ -11,7 +11,7 @@ import struct CoreLocation.CLLocationCoordinate2D
 import class MapKit.MKMapItem
 import class MapKit.MKPlacemark
 
-public protocol LocationRepresentable {
+public protocol KLocationRepresentable {
     var latitude: Double { get }
     var longitude: Double { get }
     /// - Note: This property is not supported by all navigation apps.
@@ -19,7 +19,7 @@ public protocol LocationRepresentable {
     var address: String? { get }
 }
 
-extension LocationRepresentable {
+extension KLocationRepresentable {
     internal var mapItem: MKMapItem {
         let placemark = MKPlacemark(coordinate: CLLocationCoordinate2D(latitude: self.latitude, longitude: self.longitude))
         let mapItem = MKMapItem(placemark: placemark)
@@ -32,7 +32,7 @@ extension LocationRepresentable {
     }
 }
 
-extension CLLocationCoordinate2D: LocationRepresentable {
+extension CLLocationCoordinate2D: KLocationRepresentable {
     public var name: String? {
         return nil
     }
@@ -42,7 +42,7 @@ extension CLLocationCoordinate2D: LocationRepresentable {
     }
 }
 
-extension Location: LocationRepresentable {
+extension KLocation: KLocationRepresentable {
     public var latitude: Double {
         return self.coordinate.latitude
     }

--- a/Sources/KMode.swift
+++ b/Sources/KMode.swift
@@ -9,7 +9,7 @@
 import Foundation
 import MapKit
 
-public enum Mode {
+public enum KMode {
     case walking
     case bicycling
     case driving
@@ -20,7 +20,7 @@ public enum Mode {
     ///
     /// - Parameter app: navigation app
     /// - Returns: For Apple Maps a `[String:String]`, `String` for anything else. `nil` if irrelevant.
-    func identifier(for app: App) -> Any? { // swiftlint:disable:this cyclomatic_complexity
+    func identifier(for app: KApp) -> Any? { // swiftlint:disable:this cyclomatic_complexity
         switch app {
         case .appleMaps:
             switch self {

--- a/Sources/Karte.swift
+++ b/Sources/Karte.swift
@@ -17,7 +17,7 @@ public enum Karte {
     /// - Returns: `true` if the app is installed
     /// - Warning: For this to return `true` in any case, the necessary url schemes have to be included in your app's Info.plist.
     /// Please see Karte's README for additional details.
-    public static func isInstalled(_ app: App) -> Bool {
+    public static func isInstalled(_ app: KApp) -> Bool {
         guard app != .appleMaps else { return true } // FIXME: See issue #3
         guard let url = URL(string: app.urlScheme) else { return false }
         return UIApplication.shared.canOpenURL(url)
@@ -29,9 +29,9 @@ public enum Karte {
     ///   - app: the app to be launched
     ///   - origin: an optional origin location, defaults to the user's locatino if left empty in most apps
     ///   - destination: the location to route to
-    public static func launch(app: App,
-                              origin: LocationRepresentable? = nil,
-                              destination: LocationRepresentable) {
+    public static func launch(app: KApp,
+                              origin: KLocationRepresentable? = nil,
+                              destination: KLocationRepresentable) {
         try? _launch(app: app, origin: origin, destination: destination, mode: nil)
     }
 
@@ -43,19 +43,19 @@ public enum Karte {
     ///   - destination: the location to route to
     ///   - mode: mode of transport to use
     /// - Throws: `Karte.Error.unsupportedMode` if the chosen mode is not supported by the target app
-    public static func launch(app: App,
-                              origin: LocationRepresentable? = nil,
-                              destination: LocationRepresentable,
-                              mode: Mode) throws {
+    public static func launch(app: KApp,
+                              origin: KLocationRepresentable? = nil,
+                              destination: KLocationRepresentable,
+                              mode: KMode) throws {
         try _launch(app: app, origin: origin, destination: destination, mode: mode)
     }
 
-    private static func _launch(app: App,
-                                origin: LocationRepresentable?,
-                                destination: LocationRepresentable,
-                                mode: Mode?) throws {
+    private static func _launch(app: KApp,
+                                origin: KLocationRepresentable?,
+                                destination: KLocationRepresentable,
+                                mode: KMode?) throws {
         guard app != .appleMaps else {
-            guard app.supports(mode: mode) else { throw Error.unsupportedMode }
+            guard app.supports(mode: mode) else { throw KError.unsupportedMode }
             // If mode (as in the launchOptions below) stays nil, Apple Maps won't go directly to the route, but show search boxes with prefilled content instead.
             let modeKey = (mode?.identifier(for: .appleMaps) as? [String: String]) ?? [MKLaunchOptionsDirectionsModeKey: MKLaunchOptionsDirectionsModeDefault]
             MKMapItem.openMaps(with: [origin, destination].compactMap { $0?.mapItem }, launchOptions: modeKey)
@@ -63,7 +63,7 @@ public enum Karte {
         }
 
         guard let queryString = app.queryString(origin: origin, destination: destination, mode: mode) else {
-            throw Error.unsupportedMode
+            throw KError.unsupportedMode
         }
 
         guard let url = URL(string: queryString) else {
@@ -86,16 +86,16 @@ public enum Karte {
     ///   - cancel: label for the cancel button, defaults to "Cancel"
     ///   - style: the `UIAlertController`'s style, defaults to `.actionSheet`
     /// - Returns: the alert view controller
-    public static func createPicker(origin: LocationRepresentable? = nil,
-                                    destination: LocationRepresentable,
-                                    mode: Mode? = nil,
+    public static func createPicker(origin: KLocationRepresentable? = nil,
+                                    destination: KLocationRepresentable,
+                                    mode: KMode? = nil,
                                     title: String? = nil,
                                     message: String? = nil,
                                     cancel: String = "Cancel",
                                     style: UIAlertControllerStyle = .actionSheet) -> UIAlertController {
         let alert = UIAlertController(title: title, message: message, preferredStyle: style)
 
-        App.all
+        KApp.all
             .filter(self.isInstalled)
             .filter { $0.supports(mode: mode) } // defaults to true if mode is nil
             .map { app in
@@ -121,9 +121,9 @@ public enum Karte {
     ///   - message: an optional message for the `UIAlertController`
     ///   - cancel: label for the cancel button, defaults to "Cancel"
     ///   - style: the `UIAlertController`'s style, defaults to `.actionSheet`
-    public static func presentPicker(origin: LocationRepresentable? = nil,
-                                     destination: LocationRepresentable,
-                                     mode: Mode? = nil,
+    public static func presentPicker(origin: KLocationRepresentable? = nil,
+                                     destination: KLocationRepresentable,
+                                     mode: KMode? = nil,
                                      presentOn viewcontroller: UIViewController,
                                      title: String? = nil,
                                      message: String? = nil,

--- a/Tests/KarteTests/KarteTests.swift
+++ b/Tests/KarteTests/KarteTests.swift
@@ -15,53 +15,53 @@ import struct CoreLocation.CLLocationCoordinate2D
 
 class KarteTests: XCTestCase {
 
-    var berlin: Location!
-    var dresden: Location!
+    var berlin: KLocation!
+    var dresden: KLocation!
 
-    var anonymousLocation: Location!
-    var namedLocation: Location!
-    var fullLocation: Location!
+    var anonymousLocation: KLocation!
+    var namedLocation: KLocation!
+    var fullLocation: KLocation!
 
     override func setUp() {
         let berlinCoordinate = CLLocationCoordinate2D(latitude: 52.5205356, longitude: 13.4124354)
-        self.berlin = Location(name: "Berlin", coordinate: berlinCoordinate)
+        self.berlin = KLocation(name: "Berlin", coordinate: berlinCoordinate)
 
         let dresdenCoordinate = CLLocationCoordinate2D(latitude: 51.0527491, longitude: 13.7383025)
-        self.dresden = Location(name: "Dresden", coordinate: dresdenCoordinate)
+        self.dresden = KLocation(name: "Dresden", coordinate: dresdenCoordinate)
 
         let dummyCoordinate = CLLocationCoordinate2D(latitude: 10.0, longitude: 10.0)
-        self.anonymousLocation = Location(coordinate: dummyCoordinate)
-        self.namedLocation = Location(name: "Named Location", coordinate: dummyCoordinate)
-        self.fullLocation = Location(name: "Full Location", address: "Location Address", coordinate: dummyCoordinate)
+        self.anonymousLocation = KLocation(coordinate: dummyCoordinate)
+        self.namedLocation = KLocation(name: "Named Location", coordinate: dummyCoordinate)
+        self.fullLocation = KLocation(name: "Full Location", address: "Location Address", coordinate: dummyCoordinate)
     }
 
     func testExistenceOfMapsApps() {
         var count = 0
-        for _ in iterateEnum(App.self) {
+        for _ in iterateEnum(KApp.self) {
             count += 1
         }
-        XCTAssertEqual(Set(App.all).count, count, "Please ensure that `MapsApp.all` contains all cases")
+        XCTAssertEqual(Set(KApp.all).count, count, "Please ensure that `MapsApp.all` contains all cases")
     }
 
     func testQueryStrings() {
-        XCTAssertEqual(App.googleMaps.queryString(origin: anonymousLocation, destination: namedLocation, mode: nil), "comgooglemaps://maps?daddr=10.0,10.0&saddr=10.0,10.0")
-        XCTAssertEqual(App.citymapper.queryString(origin: namedLocation, destination: fullLocation, mode: nil), "citymapper://directions?endaddress=Location%20Address&endcoord=10.0,10.0&endname=Full%20Location&startcoord=10.0,10.0&startname=Named%20Location")
-        XCTAssertEqual(App.transit.queryString(origin: anonymousLocation, destination: namedLocation, mode: nil), "transit://directions?from=10.0,10.0&to=10.0,10.0")
-        XCTAssertEqual(App.lyft.queryString(origin: anonymousLocation, destination: namedLocation, mode: nil), "lyft://ridetype?id=lyft&destination[latitude]=10.0&destination[longitude]=10.0&pickup[latitude]=10.0&pickup[longitude]=10.0")
-        XCTAssertEqual(App.uber.queryString(origin: anonymousLocation, destination: namedLocation, mode: nil), "uber://?action=setPickup&dropoff[latitude]=10.0&dropoff[longitude]=10.0&dropoff[nickname]=Named%20Location&pickup[latitude]=10.0&pickup[longitude]=10.0")
-        XCTAssertEqual(App.navigon.queryString(origin: anonymousLocation, destination: namedLocation, mode: nil), "navigon://coordinate/Named%20Location/10.0/10.0")
-        XCTAssertEqual(App.waze.queryString(origin: anonymousLocation, destination: namedLocation, mode: nil), "waze://?ll=10.0,10.0&navigate=yes")
-        XCTAssertEqual(App.yandex.queryString(origin: anonymousLocation, destination: namedLocation, mode: nil), "yandexnavi://build_route_on_map?lat_from=10.0&lat_to=10.0&lon_from=10.0&lon_to=10.0")
-        XCTAssertEqual(App.moovit.queryString(origin: anonymousLocation, destination: namedLocation, mode: nil), "moovit://directions?dest_lat=10.0&dest_lon=10.0&dest_name=Named%20Location&origin_lat=10.0&origin_lon=10.0")
+        XCTAssertEqual(KApp.googleMaps.queryString(origin: anonymousLocation, destination: namedLocation, mode: nil), "comgooglemaps://maps?daddr=10.0,10.0&saddr=10.0,10.0")
+        XCTAssertEqual(KApp.citymapper.queryString(origin: namedLocation, destination: fullLocation, mode: nil), "citymapper://directions?endaddress=Location%20Address&endcoord=10.0,10.0&endname=Full%20Location&startcoord=10.0,10.0&startname=Named%20Location")
+        XCTAssertEqual(KApp.transit.queryString(origin: anonymousLocation, destination: namedLocation, mode: nil), "transit://directions?from=10.0,10.0&to=10.0,10.0")
+        XCTAssertEqual(KApp.lyft.queryString(origin: anonymousLocation, destination: namedLocation, mode: nil), "lyft://ridetype?id=lyft&destination[latitude]=10.0&destination[longitude]=10.0&pickup[latitude]=10.0&pickup[longitude]=10.0")
+        XCTAssertEqual(KApp.uber.queryString(origin: anonymousLocation, destination: namedLocation, mode: nil), "uber://?action=setPickup&dropoff[latitude]=10.0&dropoff[longitude]=10.0&dropoff[nickname]=Named%20Location&pickup[latitude]=10.0&pickup[longitude]=10.0")
+        XCTAssertEqual(KApp.navigon.queryString(origin: anonymousLocation, destination: namedLocation, mode: nil), "navigon://coordinate/Named%20Location/10.0/10.0")
+        XCTAssertEqual(KApp.waze.queryString(origin: anonymousLocation, destination: namedLocation, mode: nil), "waze://?ll=10.0,10.0&navigate=yes")
+        XCTAssertEqual(KApp.yandex.queryString(origin: anonymousLocation, destination: namedLocation, mode: nil), "yandexnavi://build_route_on_map?lat_from=10.0&lat_to=10.0&lon_from=10.0&lon_to=10.0")
+        XCTAssertEqual(KApp.moovit.queryString(origin: anonymousLocation, destination: namedLocation, mode: nil), "moovit://directions?dest_lat=10.0&dest_lon=10.0&dest_name=Named%20Location&origin_lat=10.0&origin_lon=10.0")
     }
 
     func testModeIdentifier() {
-        XCTAssertEqual(Mode.walking.identifier(for: .appleMaps) as? [String: String], [MKLaunchOptionsDirectionsModeKey: MKLaunchOptionsDirectionsModeWalking])
-        XCTAssertNil(Mode.bicycling.identifier(for: .appleMaps))
+        XCTAssertEqual(KMode.walking.identifier(for: .appleMaps) as? [String: String], [MKLaunchOptionsDirectionsModeKey: MKLaunchOptionsDirectionsModeWalking])
+        XCTAssertNil(KMode.bicycling.identifier(for: .appleMaps))
 
-        XCTAssertEqual(Mode.driving.identifier(for: .googleMaps) as? String, "driving")
+        XCTAssertEqual(KMode.driving.identifier(for: .googleMaps) as? String, "driving")
 
-        XCTAssertNil(Mode.transit.identifier(for: .transit))
+        XCTAssertNil(KMode.transit.identifier(for: .transit))
     }
 
     func testCreatePicker() {


### PR DESCRIPTION
This project is great and I have found it very useful. Thanks for the great work.

One small problem I have encountered is how how generic the names of the structs and enums are. Location and Mode have often conflicted with my projects and other Pods due to having commonly used names.

I thought it would be useful to refactor the names of the structs and enums to avoid these conflicts. This is slightly a personal preferences so feel free to decline this PR.