### PR TITLE
Google Maps: Show the specific address when only a destination is provided

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.build
 /Packages
 /*.xcodeproj
+/.swiftpm

--- a/Sources/App.swift
+++ b/Sources/App.swift
@@ -105,8 +105,15 @@ extension Karte {
                 // Apple Maps gets special handling, since it uses System APIs
                 return nil
             case .googleMaps:
-                parameters.set("saddr", origin?.coordString)
-                parameters.set("daddr", destination.coordString)
+                if let origin = origin {
+                    parameters.set("saddr", origin.coordString)
+                    parameters.set("daddr", destination.coordString)
+                } else if let destinationAddress = destination.address {
+                    parameters.set("daddr", destinationAddress)
+                    parameters.set("center", destination.coordString)
+                } else {
+                    parameters.set("daddr", destination.coordString)
+                }
 
                 let modeIdentifier = mode?.identifier(for: self) as? String
                 parameters.set("directionsmode", modeIdentifier)


### PR DESCRIPTION
It's possible to get Google Maps to show the `address` of the `destination`. This is really useful for showing users directions from their current location to a destination address. Without this change they only see the coordinates, which isn't very useful for delivery services.